### PR TITLE
maxzoomlevel for searchlist

### DIFF
--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -364,7 +364,7 @@ const Search = function Search(options = {}) {
                     .then((res) => {
                       if (res.length > 0) {
                         const featLayerName = layer.get('name');
-                        featureInfo.showFeatureInfo({ feature: res, layerName: featLayerName });
+                        featureInfo.showFeatureInfo({ feature: res, layerName: featLayerName }, { maxZoomLevel });
                       }
                     });
                 });
@@ -392,7 +392,7 @@ const Search = function Search(options = {}) {
                     .then((res) => {
                       if (res.length > 0) {
                         const featureLayerName = layer.get('name');
-                        featureInfo.showFeatureInfo({ feature: res, layerName: featureLayerName });
+                        featureInfo.showFeatureInfo({ feature: res, layerName: featureLayerName }, { maxZoomLevel });
                       }
                     });
                 });

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -605,9 +605,15 @@ const Featureinfo = function Featureinfo(options = {}) {
   * @param {any} featureObj An object containing layerName and feature. "feature" is either one Feature or an Array of Feature
   * @param {any} opts An object containing options. Supported options are : coordinate, the coordinate where popup will be shown. If omitted first feature is used.
   *                                                                         ignorePan, do not autopan if type is overlay. Pan should be supressed if view is changed manually to avoid contradicting animations.
+  *                                                                         maxZoomLevel, max level for zooming on feature.
   * @returns nothing
   */
-  const showFeatureInfo = function showFeatureInfo(featureObj, opts = { ignorePan: true }) {
+  const showFeatureInfo = function showFeatureInfo(featureObj, opts) {
+    const thisOpts = { ...{
+      ignorePan: true
+    },
+    ...opts };
+
     const newItems = [];
     const layerName = featureObj.layerName;
     const layer = viewer.getLayer(layerName);
@@ -623,8 +629,8 @@ const Featureinfo = function Featureinfo(options = {}) {
       newItems.push(newItem);
     }
     if (newItems.length > 0) {
-      render(newItems, identifyTarget, opts.coordinate || maputils.getCenter(newItems[0].getFeature().getGeometry()), opts);
-      viewer.getMap().getView().fit(maputils.getExtent(newItems.map(i => i.getFeature())));
+      render(newItems, identifyTarget, thisOpts.coordinate || maputils.getCenter(newItems[0].getFeature().getGeometry()), thisOpts);
+      viewer.getMap().getView().fit(maputils.getExtent(newItems.map(i => i.getFeature())), { maxZoom: thisOpts.maxZoomLevel });
     }
   };
 


### PR DESCRIPTION
### Description

In this pull request, there are modifications made to the `Search` and `Featureinfo` modules. The changes involve updating the `showFeatureInfo` function to include a new option `maxZoomLevel` which specifies the maximum zoom level for zooming on a feature. 

Here are the key changes in the code:
- In `search.js`:
  - Added a `maxZoomLevel` parameter to the `featureInfo.showFeatureInfo` function calls.

- In `featureinfo.js`:
  - Updated the `showFeatureInfo` function to accept an `opts` parameter directly.
  - Added handling for `maxZoomLevel` in the `showFeatureInfo` function to control the maximum zoom level when fitting the view.
  
These changes enhance the functionality of displaying feature information by providing control over the maximum zoom level used when focusing on a feature.